### PR TITLE
Missing virtual on dtor on a base class

### DIFF
--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -204,7 +204,7 @@ namespace nzmqt
 #endif
         };
 
-        ~ZMQSocket();
+        virtual ~ZMQSocket();
 
         using zmqsuper::operator void *;
 
@@ -338,7 +338,7 @@ namespace nzmqt
         // Deleting children is necessary, because otherwise the children are deleted after the context
         // which results in a blocking state. So we delete the children before the zmq::context_t
         // destructor implementation is called.
-        ~ZMQContext();
+        virtual ~ZMQContext();
 
         using zmqsuper::operator void*;
 


### PR DESCRIPTION
This could result in bad clean up if these types are used
polymorphically.

FOS-1041