### PR TITLE
FOS-1041: Ensure the build works correctly in docker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(nzmqt SHARED "")
 target_include_directories(
     nzmqt
     PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     ${cppzmq_INCLUDE_DIR}
     ${Qt5Core_INCLUDE_DIRS}


### PR DESCRIPTION
I apparently didn't actually destroy and recreate my container when I tested the build and some residual bits must have allowed it to work when it should not have.