### PR TITLE
FOS-1278: Removes QSocketNotifier for the write end of the ZMQ Socket

### DIFF
--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -604,7 +604,6 @@ NZMQT_INLINE void SocketNotifierZMQSocket::socketReadActivity()
 }
 
 
-
 /*
  * SocketNotifierZMQContext
  */

--- a/include/nzmqt/impl.hpp
+++ b/include/nzmqt/impl.hpp
@@ -564,15 +564,11 @@ NZMQT_INLINE void PollingZMQContext::unregisterSocket(ZMQSocket* socket_)
 NZMQT_INLINE SocketNotifierZMQSocket::SocketNotifierZMQSocket(ZMQContext* context_, Type type_)
     : super(context_, type_)
     , socketNotifyRead_(0)
-    , socketNotifyWrite_(0)
 {
     qintptr fd = fileDescriptor();
 
     socketNotifyRead_ = new QSocketNotifier(fd, QSocketNotifier::Read, this);
     QObject::connect(socketNotifyRead_, &QSocketNotifier::activated, this, &SocketNotifierZMQSocket::socketReadActivity);
-
-    socketNotifyWrite_ = new QSocketNotifier(fd, QSocketNotifier::Write, this);
-    QObject::connect(socketNotifyWrite_, &QSocketNotifier::activated, this, &SocketNotifierZMQSocket::socketWriteActivity);
 }
 
 NZMQT_INLINE SocketNotifierZMQSocket::~SocketNotifierZMQSocket()
@@ -583,7 +579,6 @@ NZMQT_INLINE SocketNotifierZMQSocket::~SocketNotifierZMQSocket()
 NZMQT_INLINE void SocketNotifierZMQSocket::close()
 {
     socketNotifyRead_->deleteLater();
-    socketNotifyWrite_->deleteLater();
     super::close();
 }
 
@@ -606,27 +601,6 @@ NZMQT_INLINE void SocketNotifierZMQSocket::socketReadActivity()
     }
 
     socketNotifyRead_->setEnabled(true);
-}
-
-NZMQT_INLINE void SocketNotifierZMQSocket::socketWriteActivity()
-{
-    socketNotifyWrite_->setEnabled(false);
-
-    try
-    {
-        while (isConnected() && (events() & EVT_POLLIN))
-        {
-            const QList<QByteArray> & message = receiveMessage();
-            emit messageReceived(message);
-        }
-    }
-    catch (const ZMQException& ex)
-    {
-        qWarning("Exception during write: %s", ex.what());
-        emit notifierError(ex.num(), ex.what());
-    }
-
-    socketNotifyWrite_->setEnabled(true);
 }
 
 

--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -506,11 +506,9 @@ namespace nzmqt
 
     protected slots:
         void socketReadActivity();
-        void socketWriteActivity();
 
     private:
         QSocketNotifier *socketNotifyRead_;
-        QSocketNotifier *socketNotifyWrite_;
     };
 
     class NZMQT_API SocketNotifierZMQContext : public ZMQContext


### PR DESCRIPTION
It makes no sense to have a QSocketNotifier for the write end of the ZMQ
socket. Most sockets are available for writing most of the time. With no
way to disable this notifier from the public interface for the socket,
the socket notifier constantly emits the signal that its available for
writing resulting in stealing of 100% of CPU cycles.

Edit: Even more bizarre is that the socketWriteActivity slot seems to be triggering
the socket to try to receiveMessage(). What is going on?!