### PR TITLE
[FOS-1199] Update socket Options to support querying endpoint addresses.

### DIFF
--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -177,6 +177,7 @@ namespace nzmqt
 #ifdef ZMQ_REQ_RELAXED
             OPT_REQ_RELAXED = ZMQ_REQ_RELAXED,
 #endif
+            OPT_LAST_ENDPOINT = ZMQ_LAST_ENDPOINT,
 
             // Get and set.
             OPT_AFFINITY = ZMQ_AFFINITY,


### PR DESCRIPTION
The new Option can be used to query a ZMQSocket's last endpoint. When
queried, the last endpoint value is written into a fixed size buffer.
This Option is necessary so that applications can dynamically assign
port numbers and query the result.