### PR TITLE
[FOS-1783] Fix sequencing of receives when zmq_send results in POLLIN

### DIFF
--- a/include/nzmqt/nzmqt.hpp
+++ b/include/nzmqt/nzmqt.hpp
@@ -309,6 +309,8 @@ namespace nzmqt
         // If an empty list is provided this method doesn't do anything and returns trua.
         bool sendMessage(const QList<QByteArray>& msg_, nzmqt::ZMQSocket::SendFlags flags_ = SND_DONTWAIT);
 
+        // Slot called internally to query the events() flags from the event loop after a sendMessage call.
+        void checkEvents();
 
     protected:
         ZMQSocket(ZMQContext* context_, Type type_);


### PR DESCRIPTION
The fundamental problem here was emitting a messageReceived signal from
within the sendMessage() method. If any of the slots connected to
messageReceived are reachable via a Qt::DirectConnection, the slot
method is invoked directly in the sendMessage() method. This can result
in unexpected re-entrant code execution paths and/or corrupted ZMQ
socket messages.

Consider the case where the call to sendMessage() emits the
messageReceived signal when part of a message was transmitted (i.e.
SND_MORE is set). If a slot directly connected to the messageReceived
signal attempts to call sendMessage() again for the same socket with a
part of a completely different message, the messages out will be
corrupted.

By invoking the socket's checkEvents() slot via a Qt::QueuedConnection,
the events flags will be polled from the main event loop and will emit
the messageReceived signal from there when necessary.